### PR TITLE
Empty function parameters need void

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -6,7 +6,7 @@
 #include "constants.h"
 #include "components.h"
 
-int main() {
+int main(void) {
 	Terminal terminal;
 
 	Terminal_Init(&terminal);

--- a/source/sdl.c
+++ b/source/sdl.c
@@ -2,7 +2,7 @@
 #include "util.h"
 #include "constants.h"
 
-struct Video Video_Init() {
+struct Video Video_Init(void) {
 	struct Video ret;
 
 	// initialise SDL2

--- a/source/sdl.h
+++ b/source/sdl.h
@@ -12,7 +12,7 @@ typedef struct Video {
 	int           charHeight;
 } Video;
 
-Video Video_Init();
+Video Video_Init(void);
 void  Video_Free(Video* video);
 void  Video_OpenFont(Video* video, char* path);
 void  Video_FreeFont(Video* video);


### PR DESCRIPTION
Added `void` to empty function parameters to suppress the -Werror errors. Having no parameters without void is deprecated.

```sh
error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
```
