### PR TITLE
Added string index for isdigit() check

### DIFF
--- a/source/util.c
+++ b/source/util.c
@@ -26,7 +26,7 @@ bool StringStartsWith(char* str, char* with) {
 
 bool StringIsNumeric(char* str) {
 	for (size_t i = 0; i < strlen(str); ++ i) {
-		if (!isdigit(str)) {
+		if (!isdigit(str[i])) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Function arguments were off: you provided a string where a char is expected. This PR fixes that by using the index provided by the for loop to point to the next character in sequence.