### PR TITLE
Fixed issue with invalid config path

### DIFF
--- a/source/config.c
+++ b/source/config.c
@@ -103,7 +103,8 @@ void LoadConfig(ColourScheme* colourScheme) {
 	}
 
 	strcpy(path, home);
-	strcat(path, CONFIG_FOLDER + 1);
+    const char* config_path = CONFIG_FOLDER;
+	strcat(path, config_path + 1); 
 
 	if (access(path, F_OK) != 0) {
 		if (mkdir(path, 0777) != 0) {


### PR DESCRIPTION
You were trying to add 1 to a macro string... that doesn't work like it would for `const char*`s and `char*`s. Anyways, it's fixed now.

--- 

Maybe if you get the address of the first character in the macro and increment the offset like you would with regular strings. I haven't tried that tho.

__Update__

``` c
// This works, but it's IMO way uglier than my original alternative.
strcat(path, (const char*) &CONFIG_FOLDER + 1); 
```