### PR TITLE
tabs should be on boundary, not a fixed width

### DIFF
--- a/source/textScreen.c
+++ b/source/textScreen.c
@@ -90,7 +90,7 @@ void TextScreen_PutCharacter(TextScreen* text, char ch) {
 			break;
 		}
 		case '\t': {
-			text->cursor.x += 4;
+			text->cursor.x += 4 - text->cursor.x % 4;
 			break;
 		}
 		case 0x07: { // bell


### PR DESCRIPTION
This implements tabs properly, they should only put spaces up until the next tab width boundary, not just be a fixed number of spaces wide.